### PR TITLE
Add twin beam to girafarig's learnset

### DIFF
--- a/armips/data/levelupdata.s
+++ b/armips/data/levelupdata.s
@@ -4620,7 +4620,8 @@ levelup SPECIES_GIRAFARIG
     learnset MOVE_PSYBEAM, 19
     learnset MOVE_AGILITY, 23
     learnset MOVE_DOUBLE_HIT, 28
-    learnset MOVE_ZEN_HEADBUTT, 32
+    learnset MOVE_ZEN_HEADBUTT, 31
+    learnset MOVE_TWIN_BEAM, 32
     learnset MOVE_CRUNCH, 37
     learnset MOVE_BATON_PASS, 41
     learnset MOVE_NASTY_PLOT, 46
@@ -22022,6 +22023,7 @@ levelup SPECIES_FARIGIRAF
     learnset MOVE_PSYBEAM, 19
     learnset MOVE_AGILITY, 23
     learnset MOVE_DOUBLE_HIT, 28
+    learnset MOVE_ZEN_HEADBUTT, 31
     learnset MOVE_TWIN_BEAM, 32
     learnset MOVE_CRUNCH, 37
     learnset MOVE_BATON_PASS, 41


### PR DESCRIPTION
Girafarig can't learn twin beam by default, preventing it from evolving. This change should allow it to learn the move at level 32 like in SV. I haven't been able to test though because I keep running into unrelated errors when building test.nds.